### PR TITLE
Remove unecessary `#pragma once` header guards

### DIFF
--- a/src/arg_parser.hpp
+++ b/src/arg_parser.hpp
@@ -1,7 +1,5 @@
 /* vim: set filetype=cpp : */
 
-#pragma once
-
 #ifndef ARG_PARSER_HPP
 #define ARG_PARSER_HPP
 

--- a/src/benchmark.hpp
+++ b/src/benchmark.hpp
@@ -1,7 +1,5 @@
 /* vim: set filetype=cpp : */
 
-#pragma once
-
 #ifndef BENCHMARK_HPP
 #define BENCHMARK_HPP
 

--- a/src/hungarian.hpp
+++ b/src/hungarian.hpp
@@ -1,7 +1,5 @@
 /* vim: set filetype=cpp : */
 
-#pragma once
-
 #ifndef HUNGARIAN_HPP
 #define HUNGARIAN_HPP
 

--- a/src/hungarian.tpp
+++ b/src/hungarian.tpp
@@ -1,7 +1,5 @@
 /* vim: set filetype=cpp : */
 
-#pragma once
-
 #ifndef HUNGARIAN_TPP
 #define HUNGARIAN_TPP
 

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -1,7 +1,5 @@
 /* vim: set filetype=cpp : */
 
-#pragma once
-
 #ifndef IO_HPP
 #define IO_HPP
 

--- a/src/matrix.hpp
+++ b/src/matrix.hpp
@@ -1,7 +1,5 @@
 /* vim: set filetype=cpp : */
 
-#pragma once
-
 #ifndef MATRIX_HPP
 #define MATRIX_HPP
 

--- a/src/matrix.tpp
+++ b/src/matrix.tpp
@@ -1,7 +1,5 @@
 /* vim: set filetype=cpp : */
 
-#pragma once
-
 #ifndef MATRIX_TPP
 #define MATRIX_TPP
 

--- a/src/matrix_helpers.hpp
+++ b/src/matrix_helpers.hpp
@@ -1,7 +1,5 @@
 /* vim: set filetype=cpp : */
 
-#pragma once
-
 #ifndef MATRIX_HELPERS_HPP
 #define MATRIX_HELPERS_HPP
 

--- a/src/matrix_helpers.tpp
+++ b/src/matrix_helpers.tpp
@@ -1,7 +1,5 @@
 /* vim: set filetype=cpp : */
 
-#pragma once
-
 #ifndef MATRIX_HELPERS_TPP
 #define MATRIX_HELPERS_TPP
 

--- a/src/random.hpp
+++ b/src/random.hpp
@@ -1,7 +1,5 @@
 /* vim: set filetype=cpp : */
 
-#pragma once
-
 #ifndef RANDOM_HPP
 #define RANDOM_HPP
 

--- a/src/random.tpp
+++ b/src/random.tpp
@@ -1,7 +1,5 @@
 /* vim: set filetype=cpp : */
 
-#pragma once
-
 #ifndef RANDOM_TPP
 #define RANDOM_TPP
 

--- a/src/timed_hungarian.hpp
+++ b/src/timed_hungarian.hpp
@@ -1,7 +1,5 @@
 /* vim: set filetype=cpp : */
 
-#pragma once
-
 #ifndef TIMED_HUNGARIAN_HPP
 #define TIMED_HUNGARIAN_HPP
 

--- a/src/timed_hungarian.tpp
+++ b/src/timed_hungarian.tpp
@@ -1,7 +1,5 @@
 /* vim: set filetype=cpp : */
 
-#pragma once
-
 #ifndef TIMED_HUNGARIAN_TPP
 #define TIMED_HUNGARIAN_TPP
 

--- a/src/timer.hpp
+++ b/src/timer.hpp
@@ -1,7 +1,5 @@
 /* vim: set filetype=cpp : */
 
-#pragma once
-
 #ifndef TIMER_HPP
 #define TIMER_HPP
 


### PR DESCRIPTION
We don't need both traditional header guards (`#ifndef`, `#define`, `#endif`) as well as `#pragma once` header guards